### PR TITLE
Styleguide integration fixes

### DIFF
--- a/lib/scss/mobile.scss
+++ b/lib/scss/mobile.scss
@@ -1,1 +1,1 @@
-@import '~styleguide-test/lib/styleguide.css';
+@import '~styleguide-test/lib/styleguide';

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "webpack-svgstore-plugin": "^2.2.2"
   },
   "dependencies": {
+    "jquery": "^2.2.4",
     "jquery-browser-plugin": "0.0.6",
     "jquery.event.move": "^1.3.6",
     "jquery.event.swipe": "^0.5.4",


### PR DESCRIPTION
This provides fixes for the following:

- make jQuery a dependency since it's a peer dependency from styleguide-test
- remove css extension to allow for style guide css to be loaded (sorry about that, I got mixed up with the file extension stuff when it's really not needed here)